### PR TITLE
Change dependency version for swift-tools-support-core

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,12 +11,21 @@
         }
       },
       {
+        "package": "swift-system",
+        "repositoryURL": "https://github.com/apple/swift-system.git",
+        "state": {
+          "branch": null,
+          "revision": "836bc4557b74fe6d2660218d56e3ce96aff76574",
+          "version": "1.1.1"
+        }
+      },
+      {
         "package": "swift-tools-support-core",
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": null,
-          "revision": "3b6b97d612b56e25d80d0807f5bc38ea08b7bdf3",
-          "version": "0.2.3"
+          "revision": "93784c59434dbca8e8a9e4b700d0d6d94551da6a",
+          "version": "0.5.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .executable(name: "tuist-up", targets: ["tuist-up"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-tools-support-core.git", .upToNextMinor(from: "0.2.0")),
+        .package(url: "https://github.com/apple/swift-tools-support-core.git", from: "0.5.2"),
         .package(url: "https://github.com/mtynior/ColorizeSwift.git", from: "1.5.0")
     ],
     targets: [


### PR DESCRIPTION
Changed a dependency for `swift-tools-support-core` to version `0.5.2` that fixes the opened issue #1 